### PR TITLE
Correct typo accrording to Swift API Design Guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # SimpleLottery
+![platform-iOS](https://img.shields.io/badge/platform-ios-lightgrey.svg)
+![xcode-10.2](https://img.shields.io/badge/xcode-10.2-blue.svg)
+![swift-5.0](https://img.shields.io/badge/swift-5.0-orange.svg)
+
 SimpleLottery is based on [here](https://www.slipp.net/questions/590) for test-driven development training.  
 Code is always focused on **clarity** and **readability**.
 

--- a/SimpleLottery/AppDelegate.swift
+++ b/SimpleLottery/AppDelegate.swift
@@ -14,7 +14,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        // Override point for customization after application launch.
         return true
     }
 

--- a/SimpleLottery/AppDelegate.swift
+++ b/SimpleLottery/AppDelegate.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 
+
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
@@ -18,4 +19,3 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
 }
-

--- a/SimpleLottery/Controller/ViewController.swift
+++ b/SimpleLottery/Controller/ViewController.swift
@@ -27,16 +27,16 @@ class ViewController: UIViewController {
         self.printResult(of: checkedLotteries)
     }
     
-    private func printResult(of checkedLotteries: [LotteryWinningGrade]) {
-        let losings = checkedLotteries.filter { $0.ranking == 6 }
-        let fifthWinnings = checkedLotteries.filter { $0.ranking == 5 }
-        let fourthWinnings = checkedLotteries.filter { $0.ranking == 4 }
-        let thirdWinnings = checkedLotteries.filter { $0.ranking == 3 }
-        let secondWinnings = checkedLotteries.filter { $0.ranking == 2 }
-        let firstWinnings = checkedLotteries.filter { $0.ranking == 1 }
+    private func printResult(of lotteries: [LotteryWinningGrade]) {
+        let losings = lotteries.filter { $0.ranking == 6 }
+        let fifthWinnings = lotteries.filter { $0.ranking == 5 }
+        let fourthWinnings = lotteries.filter { $0.ranking == 4 }
+        let thirdWinnings = lotteries.filter { $0.ranking == 3 }
+        let secondWinnings = lotteries.filter { $0.ranking == 2 }
+        let firstWinnings = lotteries.filter { $0.ranking == 1 }
         
-        let purchaseAmount = Lottery.price * checkedLotteries.count
-        let profit = checkedLotteries.reduce(0) { $0 + $1.prize } - purchaseAmount
+        let purchaseAmount = Lottery.price * lotteries.count
+        let profit = lotteries.reduce(0) { $0 + $1.prize } - purchaseAmount
         let profitRate = Double(profit) / Double(purchaseAmount) * 100.0
         
         print("Number of losings is \(losings.count).")

--- a/SimpleLottery/Controller/ViewController.swift
+++ b/SimpleLottery/Controller/ViewController.swift
@@ -8,16 +8,21 @@
 
 import UIKit
 
+
 class ViewController: UIViewController {
     
-    private let purchaser = LotteryPurchaser()
-    private let winningChecker = LotteryWinningChecker()
+    // MARK: - override
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
         self.setup()
     }
+    
+    // MARK: - private
+    
+    private let purchaser = LotteryPurchaser()
+    private let winningChecker = LotteryWinningChecker()
     
     private func setup() {
         let purchaseAmount = 5_000

--- a/SimpleLottery/Controller/ViewController.swift
+++ b/SimpleLottery/Controller/ViewController.swift
@@ -27,16 +27,16 @@ class ViewController: UIViewController {
         self.printResult(of: checkedLotteries)
     }
     
-    private func printResult(of lotteries: [LotteryWinningGrade]) {
-        let losings = lotteries.filter { $0.ranking == 6 }
-        let fifthWinnings = lotteries.filter { $0.ranking == 5 }
-        let fourthWinnings = lotteries.filter { $0.ranking == 4 }
-        let thirdWinnings = lotteries.filter { $0.ranking == 3 }
-        let secondWinnings = lotteries.filter { $0.ranking == 2 }
-        let firstWinnings = lotteries.filter { $0.ranking == 1 }
+    private func printResult(of checkedLotteries: [LotteryWinningGrade]) {
+        let losings = checkedLotteries.filter { $0.ranking == 6 }
+        let fifthWinnings = checkedLotteries.filter { $0.ranking == 5 }
+        let fourthWinnings = checkedLotteries.filter { $0.ranking == 4 }
+        let thirdWinnings = checkedLotteries.filter { $0.ranking == 3 }
+        let secondWinnings = checkedLotteries.filter { $0.ranking == 2 }
+        let firstWinnings = checkedLotteries.filter { $0.ranking == 1 }
         
-        let purchaseAmount = Lottery.price * lotteries.count
-        let profit = lotteries.reduce(0) { $0 + $1.prize } - purchaseAmount
+        let purchaseAmount = Lottery.price * checkedLotteries.count
+        let profit = checkedLotteries.reduce(0) { $0 + $1.prize } - purchaseAmount
         let profitRate = Double(profit) / Double(purchaseAmount) * 100.0
         
         print("Number of losings is \(losings.count).")

--- a/SimpleLottery/Model/Lottery.swift
+++ b/SimpleLottery/Model/Lottery.swift
@@ -28,17 +28,17 @@ struct Lottery {
     // MARK: - private
     
     private static func generatedNumbers(with numbers: [Int]) -> [Int] {
-        var nonredundantNumbers = Set(numbers)
+        var uniqueNumbers = Set(numbers)
         
-        if nonredundantNumbers.count > self.numbersCount {
-            nonredundantNumbers = Set(nonredundantNumbers.prefix(self.numbersCount))
+        if uniqueNumbers.count > self.numbersCount {
+            uniqueNumbers = Set(uniqueNumbers.prefix(self.numbersCount))
         }
         
-        while nonredundantNumbers.count < self.numbersCount {
-            nonredundantNumbers.insert(Int.random(in: self.numberRange))
+        while uniqueNumbers.count < self.numbersCount {
+            uniqueNumbers.insert(Int.random(in: self.numberRange))
         }
         
-        return Array(nonredundantNumbers).sorted()
+        return Array(uniqueNumbers).sorted()
     }
     
 }

--- a/SimpleLottery/Model/Lottery.swift
+++ b/SimpleLottery/Model/Lottery.swift
@@ -21,7 +21,7 @@ struct Lottery {
     
     static let price = 1000
     static let numberRange = 1...45
-    static let numberMaximumCount = 6
+    static let numbersCount = 6
     
     let numbers: [Int]
     
@@ -30,11 +30,11 @@ struct Lottery {
     private static func generatedNumbers(with numbers: [Int]) -> [Int] {
         var nonredundantNumbers = Set(numbers)
         
-        if nonredundantNumbers.count > self.numberMaximumCount {
-            nonredundantNumbers = Set(nonredundantNumbers.prefix(self.numberMaximumCount))
+        if nonredundantNumbers.count > self.numbersCount {
+            nonredundantNumbers = Set(nonredundantNumbers.prefix(self.numbersCount))
         }
         
-        while nonredundantNumbers.count < self.numberMaximumCount {
+        while nonredundantNumbers.count < self.numbersCount {
             nonredundantNumbers.insert(Int.random(in: self.numberRange))
         }
         

--- a/SimpleLottery/Model/Lottery.swift
+++ b/SimpleLottery/Model/Lottery.swift
@@ -8,27 +8,34 @@
 
 import Foundation
 
+
 struct Lottery {
     
-    static let price = 1000
-    static let numbersRange = 1...45
-    static let numbersMaximumCount = 6
-    
-    let numbers: [Int]
+    // MARK - init
     
     init(numbers: [Int] = []) {
         self.numbers = Lottery.generatedNumbers(with: numbers)
     }
     
+    // MARK: - internal
+    
+    static let price = 1000
+    static let numberRange = 1...45
+    static let numberMaximumCount = 6
+    
+    let numbers: [Int]
+    
+    // MARK: - private
+    
     private static func generatedNumbers(with numbers: [Int]) -> [Int] {
         var nonredundantNumbers = Set(numbers)
         
-        if nonredundantNumbers.count > self.numbersMaximumCount {
-            nonredundantNumbers = Set(nonredundantNumbers.prefix(self.numbersMaximumCount))
+        if nonredundantNumbers.count > self.numberMaximumCount {
+            nonredundantNumbers = Set(nonredundantNumbers.prefix(self.numberMaximumCount))
         }
         
-        while nonredundantNumbers.count < self.numbersMaximumCount {
-            nonredundantNumbers.insert(Int.random(in: self.numbersRange))
+        while nonredundantNumbers.count < self.numberMaximumCount {
+            nonredundantNumbers.insert(Int.random(in: self.numberRange))
         }
         
         return Array(nonredundantNumbers).sorted()

--- a/SimpleLottery/Model/LotteryPurchaser.swift
+++ b/SimpleLottery/Model/LotteryPurchaser.swift
@@ -13,8 +13,8 @@ class LotteryPurchaser {
     
     private(set) var lotteries: [Lottery] = []
     
-    func purchase(for purchaseAmount: Int) {
-        let purchasableCount = purchaseAmount / Lottery.price
+    func purchase(for amount: Int) {
+        let purchasableCount = amount / Lottery.price
         
         while self.lotteries.count < purchasableCount {
             self.lotteries.append(Lottery())

--- a/SimpleLottery/Model/LotteryPurchaser.swift
+++ b/SimpleLottery/Model/LotteryPurchaser.swift
@@ -9,9 +9,10 @@
 import Foundation
 import os.log
 
+
 class LotteryPurchaser {
     
-    private(set) var lotteries: [Lottery] = []
+    // MARK: - internal
     
     func purchase(for amount: Int) {
         let purchasableCount = amount / Lottery.price
@@ -23,5 +24,9 @@ class LotteryPurchaser {
         os_log("You purchased %d lottories.", log: .default, type: .info, self.lotteries.count)
         self.lotteries.forEach { os_log("%s", log: .default, type: .info, $0.numbers.description) }
     }
+    
+    // MARK: - private
+    
+    private(set) var lotteries: [Lottery] = []
     
 }

--- a/SimpleLottery/Model/LotteryWinningChecker.swift
+++ b/SimpleLottery/Model/LotteryWinningChecker.swift
@@ -9,10 +9,10 @@
 import Foundation
 import os.log
 
+
 struct LotteryWinningChecker {
     
-    private(set) var winningNumbers: [Int]
-    private(set) var bonusNumber: Int
+    // MARK: - init
     
     init() {
         self.winningNumbers = Lottery().numbers
@@ -26,6 +26,8 @@ struct LotteryWinningChecker {
         os_log("Bonus number is %d.", log: .default, type: .info, self.bonusNumber)
     }
     
+    // MARK: - internal
+    
     func checkedLottery(for lottery: Lottery) -> LotteryWinningGrade {
         let matching = Set(lottery.numbers).intersection(self.winningNumbers).count
         let hasBonus = lottery.numbers.contains(self.bonusNumber)
@@ -36,5 +38,10 @@ struct LotteryWinningChecker {
     func checkedLotteries(for lotteries: [Lottery]) -> [LotteryWinningGrade] {
         return lotteries.map { self.checkedLottery(for: $0) }
     }
+    
+    // MARK - private
+    
+    private(set) var winningNumbers: [Int]
+    private(set) var bonusNumber: Int
     
 }

--- a/SimpleLottery/Model/LotteryWinningChecker.swift
+++ b/SimpleLottery/Model/LotteryWinningChecker.swift
@@ -27,10 +27,10 @@ struct LotteryWinningChecker {
     }
     
     func checkedLottery(for lottery: Lottery) -> LotteryWinningGrade {
-        let matchingCount = Set(lottery.numbers).intersection(self.winningNumbers).count
+        let matching = Set(lottery.numbers).intersection(self.winningNumbers).count
         let hasBonus = lottery.numbers.contains(self.bonusNumber)
         
-        return LotteryWinningGradeFactory.winningGrade(for: matchingCount, hasBonus: hasBonus)
+        return LotteryWinningGradeFactory.makeWinningGrade(matching: matching, hasBonus: hasBonus)
     }
     
     func checkedLotteries(for lotteries: [Lottery]) -> [LotteryWinningGrade] {

--- a/SimpleLottery/Model/LotteryWinningGrade.swift
+++ b/SimpleLottery/Model/LotteryWinningGrade.swift
@@ -66,8 +66,8 @@ struct Losing: LotteryWinningGrade {
 
 struct LotteryWinningGradeFactory {
     
-    static func winningGrade(for matchingCount: Int, hasBonus: Bool) -> LotteryWinningGrade {
-        switch matchingCount {
+    static func makeWinningGrade(matching: Int, hasBonus: Bool) -> LotteryWinningGrade {
+        switch matching {
         case 6:
             return FirstWinning()
         case 5:

--- a/SimpleLottery/Model/LotteryWinningGrade.swift
+++ b/SimpleLottery/Model/LotteryWinningGrade.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+
 protocol LotteryWinningGrade {
     
     var ranking: Int { get }
@@ -65,6 +66,8 @@ struct Losing: LotteryWinningGrade {
 
 
 struct LotteryWinningGradeFactory {
+    
+    // MARK: - Factory method pattern
     
     static func makeWinningGrade(matching: Int, hasBonus: Bool) -> LotteryWinningGrade {
         switch matching {

--- a/SimpleLotteryTests/SimpleLotteryTests.swift
+++ b/SimpleLotteryTests/SimpleLotteryTests.swift
@@ -64,7 +64,7 @@ class SimpleLotteryTests: XCTestCase {
     
     func testPurchaseLotteries() {
         // given
-        let purchaseAmount = 5000
+        let purchaseAmount = 5_000
         let purchaser = LotteryPurchaser()
         
         let expectedCount = purchaseAmount / Lottery.price

--- a/SimpleLotteryTests/SimpleLotteryTests.swift
+++ b/SimpleLotteryTests/SimpleLotteryTests.swift
@@ -12,7 +12,7 @@ import XCTest
 
 class SimpleLotteryTests: XCTestCase {
     
-    func testGeneratedNumbers() {
+    func testGeneratedNumbersCount_ShouldBeEqualToLotteryNumbersCount() {
         // given
         
         // when
@@ -20,22 +20,45 @@ class SimpleLotteryTests: XCTestCase {
         
         // then
         XCTAssertEqual(lottery.numbers.count, Lottery.numbersCount)
+    }
+    
+    func testGeneratedNumbers_ShouldBeInLotteryNumberRange() {
+        // given
+        
+        // when
+        let lottery = Lottery()
+        
+        // then
         lottery.numbers.forEach { XCTAssertTrue(Lottery.numberRange.contains($0)) }
     }
     
-    func testGeneratedNumbers_WhenNumbersCountIsExceeded() {
+    func testGeneratedNumbers_WhenNumbersCountIsExceeded_ShouldBeEqualToLotteryNumbersCount() {
         // given
-        var nonredundantNumbers: Set<Int> = []
+        var uniqueNumbers: Set<Int> = []
         
-        while nonredundantNumbers.count < Lottery.numbersCount + 1 {
-            nonredundantNumbers.insert(Int.random(in: Lottery.numberRange))
+        while uniqueNumbers.count < Lottery.numbersCount + 1 {
+            uniqueNumbers.insert(Int.random(in: Lottery.numberRange))
         }
         
         // when
-        let lottery = Lottery(numbers: Array(nonredundantNumbers).sorted())
+        let lottery = Lottery(numbers: Array(uniqueNumbers).sorted())
         
         // then
         XCTAssertEqual(lottery.numbers.count, Lottery.numbersCount)
+    }
+    
+    func testGeneratedNumbers_WhenNumbersCountIsExceeded_ShouldBeInLotteryNumberRange() {
+        // given
+        var uniqueNumbers: Set<Int> = []
+        
+        while uniqueNumbers.count < Lottery.numbersCount + 1 {
+            uniqueNumbers.insert(Int.random(in: Lottery.numberRange))
+        }
+        
+        // when
+        let lottery = Lottery(numbers: Array(uniqueNumbers).sorted())
+        
+        // then
         lottery.numbers.forEach { XCTAssertTrue(Lottery.numberRange.contains($0)) }
     }
     

--- a/SimpleLotteryTests/SimpleLotteryTests.swift
+++ b/SimpleLotteryTests/SimpleLotteryTests.swift
@@ -12,8 +12,6 @@ import XCTest
 
 class SimpleLotteryTests: XCTestCase {
     
-    let winningChecker = LotteryWinningChecker()
-    
     func testGeneratedNumbers() {
         // given
         
@@ -63,7 +61,7 @@ class SimpleLotteryTests: XCTestCase {
         let expectedPrize = 2_000_000_000
         
         // when
-        let checkedLottery = winningChecker.checkedLottery(for: lottery)
+        let checkedLottery = self.winningChecker.checkedLottery(for: lottery)
         
         // then
         XCTAssertEqual(checkedLottery.ranking, expectedRanking)
@@ -81,7 +79,7 @@ class SimpleLotteryTests: XCTestCase {
         let expectedPrize = 30_000_000
         
         // when
-        let checkedLottery = winningChecker.checkedLottery(for: lottery)
+        let checkedLottery = self.winningChecker.checkedLottery(for: lottery)
         
         // then
         XCTAssertEqual(checkedLottery.ranking, expectedRanking)
@@ -103,7 +101,7 @@ class SimpleLotteryTests: XCTestCase {
         let expectedPrize = 1_500_000
         
         // when
-        let checkedLottery = winningChecker.checkedLottery(for: lottery)
+        let checkedLottery = self.winningChecker.checkedLottery(for: lottery)
         
         // then
         XCTAssertEqual(checkedLottery.ranking, expectedRanking)
@@ -124,7 +122,7 @@ class SimpleLotteryTests: XCTestCase {
         let expectedPrize = 50_000
         
         // when
-        let checkedLottery = winningChecker.checkedLottery(for: lottery)
+        let checkedLottery = self.winningChecker.checkedLottery(for: lottery)
         
         // then
         XCTAssertEqual(checkedLottery.ranking, expectedRanking)
@@ -145,7 +143,7 @@ class SimpleLotteryTests: XCTestCase {
         let expectedPrize = 5_000
         
         // when
-        let checkedLottery = winningChecker.checkedLottery(for: lottery)
+        let checkedLottery = self.winningChecker.checkedLottery(for: lottery)
         
         // then
         XCTAssertEqual(checkedLottery.ranking, expectedRanking)
@@ -165,11 +163,15 @@ class SimpleLotteryTests: XCTestCase {
         let expectedPrize = 0
         
         // when
-        let checkedLottery = winningChecker.checkedLottery(for: lottery)
+        let checkedLottery = self.winningChecker.checkedLottery(for: lottery)
         
         // then
         XCTAssertEqual(checkedLottery.ranking, expectedRanking)
         XCTAssertEqual(checkedLottery.prize, expectedPrize)
     }
+    
+    // MARK: - private
+    
+    private let winningChecker = LotteryWinningChecker()
     
 }

--- a/SimpleLotteryTests/SimpleLotteryTests.swift
+++ b/SimpleLotteryTests/SimpleLotteryTests.swift
@@ -9,6 +9,7 @@
 import XCTest
 @testable import SimpleLottery
 
+
 class SimpleLotteryTests: XCTestCase {
     
     let winningChecker = LotteryWinningChecker()
@@ -20,24 +21,24 @@ class SimpleLotteryTests: XCTestCase {
         let lottery = Lottery()
         
         // then
-        XCTAssertEqual(lottery.numbers.count, Lottery.numbersMaximumCount)
-        lottery.numbers.forEach { XCTAssertTrue(Lottery.numbersRange.contains($0)) }
+        XCTAssertEqual(lottery.numbers.count, Lottery.numberMaximumCount)
+        lottery.numbers.forEach { XCTAssertTrue(Lottery.numberRange.contains($0)) }
     }
     
     func testGeneratedNumbers_WhenNumbersMaximumCountIsExceeded() {
         // given
         var nonredundantNumbers: Set<Int> = []
         
-        while nonredundantNumbers.count < Lottery.numbersMaximumCount + 1 {
-            nonredundantNumbers.insert(Int.random(in: Lottery.numbersRange))
+        while nonredundantNumbers.count < Lottery.numberMaximumCount + 1 {
+            nonredundantNumbers.insert(Int.random(in: Lottery.numberRange))
         }
         
         // when
         let lottery = Lottery(numbers: Array(nonredundantNumbers).sorted())
         
         // then
-        XCTAssertEqual(lottery.numbers.count, Lottery.numbersMaximumCount)
-        lottery.numbers.forEach { XCTAssertTrue(Lottery.numbersRange.contains($0)) }
+        XCTAssertEqual(lottery.numbers.count, Lottery.numberMaximumCount)
+        lottery.numbers.forEach { XCTAssertTrue(Lottery.numberRange.contains($0)) }
     }
     
     func testPurchaseLotteries() {

--- a/SimpleLotteryTests/SimpleLotteryTests.swift
+++ b/SimpleLotteryTests/SimpleLotteryTests.swift
@@ -71,8 +71,8 @@ class SimpleLotteryTests: XCTestCase {
     
     func testCheckSecondWinning() {
         // given
-        let matchingCount = 5
-        var numbers = self.winningChecker.winningNumbers.shuffled().enumerated().compactMap { $0 < matchingCount ? $1 : nil }
+        let matching = 5
+        var numbers = self.winningChecker.winningNumbers.shuffled().enumerated().compactMap { $0 < matching ? $1 : nil }
         numbers.append(self.winningChecker.bonusNumber)
         let lottery = Lottery(numbers: numbers)
         
@@ -89,11 +89,11 @@ class SimpleLotteryTests: XCTestCase {
     
     func testCheckThirdWinning() {
         // given
-        let matchingCount = 5
+        let matching = 5
         var lottery = Lottery(numbers: [self.winningChecker.bonusNumber])
         
         while lottery.numbers.contains(self.winningChecker.bonusNumber) {
-            var numbers = self.winningChecker.winningNumbers.shuffled().enumerated().compactMap { $0 < matchingCount ? $1 : nil }
+            var numbers = self.winningChecker.winningNumbers.shuffled().enumerated().compactMap { $0 < matching ? $1 : nil }
             numbers.append(Int.random(in: 1...45))
             lottery = Lottery(numbers: numbers)
         }
@@ -111,11 +111,11 @@ class SimpleLotteryTests: XCTestCase {
     
     func testCheckFourthWinning() {
         // given
-        let matchingCount = 4
+        let mathcing = 4
         var lottery = Lottery(numbers: self.winningChecker.winningNumbers)
         
-        while Set(lottery.numbers).intersection(self.winningChecker.winningNumbers).count != matchingCount {
-            let numbers = self.winningChecker.winningNumbers.shuffled().enumerated().compactMap { $0 < matchingCount ? $1 : nil }
+        while Set(lottery.numbers).intersection(self.winningChecker.winningNumbers).count != mathcing {
+            let numbers = self.winningChecker.winningNumbers.shuffled().enumerated().compactMap { $0 < mathcing ? $1 : nil }
             lottery = Lottery(numbers: numbers)
         }
         
@@ -132,11 +132,11 @@ class SimpleLotteryTests: XCTestCase {
     
     func testCheckFifthWinning() {
         // given
-        let matchingCount = 3
+        let mathcing = 3
         var lottery = Lottery(numbers: self.winningChecker.winningNumbers)
         
-        while Set(lottery.numbers).intersection(self.winningChecker.winningNumbers).count != matchingCount {
-            let numbers = self.winningChecker.winningNumbers.shuffled().enumerated().compactMap { $0 < matchingCount ? $1 : nil }
+        while Set(lottery.numbers).intersection(self.winningChecker.winningNumbers).count != mathcing {
+            let numbers = self.winningChecker.winningNumbers.shuffled().enumerated().compactMap { $0 < mathcing ? $1 : nil }
             lottery = Lottery(numbers: numbers)
         }
         

--- a/SimpleLotteryTests/SimpleLotteryTests.swift
+++ b/SimpleLotteryTests/SimpleLotteryTests.swift
@@ -19,15 +19,15 @@ class SimpleLotteryTests: XCTestCase {
         let lottery = Lottery()
         
         // then
-        XCTAssertEqual(lottery.numbers.count, Lottery.numberMaximumCount)
+        XCTAssertEqual(lottery.numbers.count, Lottery.numbersCount)
         lottery.numbers.forEach { XCTAssertTrue(Lottery.numberRange.contains($0)) }
     }
     
-    func testGeneratedNumbers_WhenNumbersMaximumCountIsExceeded() {
+    func testGeneratedNumbers_WhenNumbersCountIsExceeded() {
         // given
         var nonredundantNumbers: Set<Int> = []
         
-        while nonredundantNumbers.count < Lottery.numberMaximumCount + 1 {
+        while nonredundantNumbers.count < Lottery.numbersCount + 1 {
             nonredundantNumbers.insert(Int.random(in: Lottery.numberRange))
         }
         
@@ -35,7 +35,7 @@ class SimpleLotteryTests: XCTestCase {
         let lottery = Lottery(numbers: Array(nonredundantNumbers).sorted())
         
         // then
-        XCTAssertEqual(lottery.numbers.count, Lottery.numberMaximumCount)
+        XCTAssertEqual(lottery.numbers.count, Lottery.numbersCount)
         lottery.numbers.forEach { XCTAssertTrue(Lottery.numberRange.contains($0)) }
     }
     
@@ -152,10 +152,10 @@ class SimpleLotteryTests: XCTestCase {
     
     func testCheckLosing() {
         // given
-        let matchingMaximumCount = 2
+        let matching = 2
         var lottery = Lottery(numbers: self.winningChecker.winningNumbers)
         
-        while Set(lottery.numbers).intersection(self.winningChecker.winningNumbers).count > matchingMaximumCount {
+        while Set(lottery.numbers).intersection(self.winningChecker.winningNumbers).count > matching {
             lottery = Lottery()
         }
         


### PR DESCRIPTION
* Begin names of factory methods with “make”, e.g. x.makeIterator()